### PR TITLE
Add web AI long-text editor demo with memory and multi-provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # one-z
+
+Simple web editor demonstrating AI-assisted long text generation with segment memory.
+
+## Features
+- Stores generated segments with vector embeddings for retrieval.
+- Supports multiple providers (OpenAI, Azure OpenAI, 通义千问, DeepSeek, Kimi) with configurable base URL and API key.
+- Web interface for entering prompts and viewing results.
+
+## Usage
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the server:
+   ```bash
+   uvicorn app:app --reload
+   ```
+3. Open `http://localhost:8000` in a browser and configure provider settings.
+
+This is a minimal demo; integrate with real APIs by providing valid `base_url` and `api_key`.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,36 @@
+from typing import Dict
+from fastapi import FastAPI
+from fastapi.responses import HTMLResponse
+from pydantic import BaseModel
+
+from memory import MemoryStore
+from clients import generate_text, get_embedding
+
+app = FastAPI()
+store = MemoryStore()
+
+
+class GenerateRequest(BaseModel):
+    prompt: str
+    provider: str
+    base_url: str
+    api_key: str
+    model: str
+    embedding_model: str
+
+
+@app.post("/generate")
+def generate(req: GenerateRequest) -> Dict[str, object]:
+    cfg = req.dict()
+    query_emb = get_embedding(req.prompt, cfg)
+    related = store.search(query_emb)
+    context = "\n".join(related + [req.prompt])
+    result = generate_text(context, cfg)
+    store.add(result, get_embedding(result, cfg))
+    return {"result": result, "related": related}
+
+
+@app.get("/")
+def index() -> HTMLResponse:
+    with open("index.html", "r", encoding="utf-8") as f:
+        return HTMLResponse(f.read())

--- a/clients.py
+++ b/clients.py
@@ -1,0 +1,65 @@
+import requests
+from typing import Dict, Any
+
+# Mapping providers to header keys and default paths
+PROVIDERS = {
+    "openai": {
+        "auth": "Authorization",
+        "chat_path": "/v1/chat/completions",
+        "embed_path": "/v1/embeddings"
+    },
+    "azure": {
+        "auth": "api-key",
+        # For azure, base_url should include deployment e.g. https://{endpoint}/openai/deployments/{model}
+        "chat_path": "/chat/completions?api-version=2024-02-15-preview",
+        "embed_path": "/embeddings?api-version=2024-02-15-preview"
+    },
+    "qwen": {  # 通义千问
+        "auth": "Authorization",
+        "chat_path": "/v1/chat/completions",
+        "embed_path": "/v1/embeddings"
+    },
+    "deepseek": {
+        "auth": "Authorization",
+        "chat_path": "/v1/chat/completions",
+        "embed_path": "/v1/embeddings"
+    },
+    "kimi": {
+        "auth": "Authorization",
+        "chat_path": "/v1/chat/completions",
+        "embed_path": "/v1/embeddings"
+    },
+}
+
+
+def _request(url: str, headers: Dict[str, str], payload: Dict[str, Any]) -> Dict[str, Any]:
+    resp = requests.post(url, headers=headers, json=payload, timeout=60)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def generate_text(prompt: str, cfg: Dict[str, str]) -> str:
+    provider = cfg["provider"]
+    base = cfg["base_url"]
+    model = cfg["model"]
+    info = PROVIDERS[provider]
+    headers = {info["auth"]: f"Bearer {cfg['api_key']}" if info["auth"] == "Authorization" else cfg['api_key']}
+    url = base + info["chat_path"]
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}]
+    }
+    data = _request(url, headers, payload)
+    return data["choices"][0]["message"]["content"].strip()
+
+
+def get_embedding(text: str, cfg: Dict[str, str]) -> Any:
+    provider = cfg["provider"]
+    base = cfg["base_url"]
+    model = cfg["embedding_model"]
+    info = PROVIDERS[provider]
+    headers = {info["auth"]: f"Bearer {cfg['api_key']}" if info["auth"] == "Authorization" else cfg['api_key']}
+    url = base + info["embed_path"]
+    payload = {"model": model, "input": text}
+    data = _request(url, headers, payload)
+    return data["data"][0]["embedding"]

--- a/index.html
+++ b/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>AI Long Text Editor</title>
+</head>
+<body>
+    <h1>AI Long Text Editor</h1>
+    <label>Provider:
+        <select id="provider">
+            <option value="openai">OpenAI</option>
+            <option value="azure">Azure OpenAI</option>
+            <option value="qwen">通义千问</option>
+            <option value="deepseek">DeepSeek</option>
+            <option value="kimi">Kimi</option>
+        </select>
+    </label><br/>
+    <label>Base URL: <input id="base_url" size="50" /></label><br/>
+    <label>API Key: <input id="api_key" size="50" /></label><br/>
+    <label>Model: <input id="model" value="gpt-3.5-turbo" /></label><br/>
+    <label>Embedding Model: <input id="embedding_model" value="text-embedding-3-small" /></label><br/>
+    <textarea id="prompt" rows="6" cols="80" placeholder="输入文本...\n"></textarea><br/>
+    <button onclick="send()">Generate</button>
+    <h3>Related Segments</h3>
+    <pre id="related"></pre>
+    <h3>Result</h3>
+    <pre id="result"></pre>
+<script>
+async function send(){
+    const body = {
+        prompt: document.getElementById('prompt').value,
+        provider: document.getElementById('provider').value,
+        base_url: document.getElementById('base_url').value,
+        api_key: document.getElementById('api_key').value,
+        model: document.getElementById('model').value,
+        embedding_model: document.getElementById('embedding_model').value
+    };
+    const res = await fetch('/generate',{method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body)});
+    const data = await res.json();
+    document.getElementById('related').textContent = data.related.join('\n');
+    document.getElementById('result').textContent = data.result;
+}
+</script>
+</body>
+</html>

--- a/memory.py
+++ b/memory.py
@@ -1,0 +1,23 @@
+import numpy as np
+from typing import List, Dict
+
+class MemoryStore:
+    """Simple in-memory vector store for text segments."""
+    def __init__(self) -> None:
+        self.segments: List[Dict[str, np.ndarray]] = []
+
+    def add(self, text: str, embedding: List[float]) -> None:
+        self.segments.append({"text": text, "embedding": np.array(embedding, dtype=float)})
+
+    def search(self, embedding: List[float], top_k: int = 3) -> List[str]:
+        if not self.segments:
+            return []
+        query = np.array(embedding, dtype=float)
+        # cosine similarity
+        scores = [
+            float(np.dot(seg["embedding"], query) /
+                  (np.linalg.norm(seg["embedding"]) * np.linalg.norm(query)))
+            for seg in self.segments
+        ]
+        indices = np.argsort(scores)[::-1][:top_k]
+        return [self.segments[i]["text"] for i in indices]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+requests
+pydantic
+numpy


### PR DESCRIPTION
## Summary
- implement in-memory vector store for segment retrieval
- add API client supporting OpenAI, Azure, Qwen, DeepSeek, and Kimi with configurable base URLs
- provide FastAPI server and simple web UI for long-text generation

## Testing
- `python -m py_compile memory.py clients.py app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896384019dc833180545ab82d39b6f6