### PR TITLE
Add error handling to frontend send function

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,8 @@ Simple web editor demonstrating AI-assisted long text generation with segment me
 3. Open `http://localhost:8000` in a browser and configure provider settings.
 
 This is a minimal demo; integrate with real APIs by providing valid `base_url` and `api_key`.
+
+## Manual Test Plan
+1. Start the server: `uvicorn app:app --reload` and open `http://localhost:8000` in a browser.
+2. Enter a prompt and valid settings, then click **Generate**. A result should appear and the error area should be empty.
+3. Stop the server or disable the network and press **Generate** again. The new **Error** section displays the error message from the failed request.

--- a/index.html
+++ b/index.html
@@ -23,6 +23,8 @@
     <button onclick="send()">Generate</button>
     <h3>Related Segments</h3>
     <pre id="related"></pre>
+    <h3>Error</h3>
+    <pre id="error"></pre>
     <h3>Result</h3>
     <pre id="result"></pre>
 <script>
@@ -35,10 +37,18 @@ async function send(){
         model: document.getElementById('model').value,
         embedding_model: document.getElementById('embedding_model').value
     };
-    const res = await fetch('/generate',{method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body)});
-    const data = await res.json();
-    document.getElementById('related').textContent = data.related.join('\n');
-    document.getElementById('result').textContent = data.result;
+    try {
+        const res = await fetch('/generate',{method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body)});
+        if (!res.ok) {
+            throw new Error('Request failed with status ' + res.status);
+        }
+        const data = await res.json();
+        document.getElementById('related').textContent = data.related.join('\n');
+        document.getElementById('result').textContent = data.result;
+        document.getElementById('error').textContent = '';
+    } catch (err) {
+        document.getElementById('error').textContent = err.message || String(err);
+    }
 }
 </script>
 </body>


### PR DESCRIPTION
## Summary
- Wrap `fetch` in `index.html` with try/catch to surface errors
- Add `<pre id="error">` element to show request failures and clear it on success
- Document manual test plan for validating error handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689640898e688331a78669c7af8fdf6c