### PR TITLE
Add metadata to memory store for prompts and responses

### DIFF
--- a/app.py
+++ b/app.py
@@ -23,10 +23,14 @@ class GenerateRequest(BaseModel):
 def generate(req: GenerateRequest) -> Dict[str, object]:
     cfg = req.dict()
     query_emb = get_embedding(req.prompt, cfg)
-    related = store.search(query_emb)
+    related = store.search(query_emb, kind="prompt")
     context = "\n".join(related + [req.prompt])
+
+    # Store the prompt before generating the result so it can be retrieved later
+    store.add(req.prompt, query_emb, kind="prompt")
+
     result = generate_text(context, cfg)
-    store.add(result, get_embedding(result, cfg))
+    store.add(result, get_embedding(result, cfg), kind="response")
     return {"result": result, "related": related}
 
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -3,7 +3,11 @@ from memory import MemoryStore
 
 def test_memory_store_retrieval():
     store = MemoryStore()
-    store.add('first', [1.0, 0.0])
-    store.add('second', [0.0, 1.0])
-    results = store.search([1.0, 0.0], top_k=1)
-    assert results == ['first']
+    store.add('first', [1.0, 0.0], kind='prompt')
+    store.add('second', [0.0, 1.0], kind='response')
+
+    prompt_results = store.search([1.0, 0.0], top_k=1, kind='prompt')
+    response_results = store.search([0.0, 1.0], top_k=1, kind='response')
+
+    assert prompt_results == ['first']
+    assert response_results == ['second']


### PR DESCRIPTION
## Summary
- record prompt and response entries with metadata
- store prompts and results and search by type
- test memory store retrieval for prompt and response

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896408974988331bd243bb8573a0adb