### PR TITLE
Handle zero vector embeddings in search

### DIFF
--- a/memory.py
+++ b/memory.py
@@ -41,15 +41,19 @@ class MemoryStore:
             return []
 
         query = np.array(embedding, dtype=float)
+        query_norm = np.linalg.norm(query)
+        if query_norm == 0:
+            return []
+
         scored = []
         for seg in self.segments:
             if kind is not None and seg.get("kind") != kind:
                 continue
-            score = float(
-                np.dot(seg["embedding"], query)
-                /
-                (np.linalg.norm(seg["embedding"]) * np.linalg.norm(query))
-            )
+            seg_emb = seg["embedding"]
+            seg_norm = np.linalg.norm(seg_emb)
+            if seg_norm == 0:
+                continue
+            score = float(np.dot(seg_emb, query) / (seg_norm * query_norm))
             scored.append((score, seg["text"]))
 
         if not scored:

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -11,3 +11,15 @@ def test_memory_store_retrieval():
 
     assert prompt_results == ['first']
     assert response_results == ['second']
+
+
+def test_search_handles_zero_vectors():
+    store = MemoryStore()
+    # zero vector in store should be ignored
+    store.add('zero', [0.0, 0.0], kind='prompt')
+    store.add('one', [1.0, 0.0], kind='prompt')
+    results = store.search([1.0, 0.0], kind='prompt')
+    assert results == ['one']
+
+    # query with zero vector returns empty list
+    assert store.search([0.0, 0.0], kind='prompt') == []


### PR DESCRIPTION
## Summary
- Avoid division by zero during cosine similarity when query or stored embeddings are zero vectors
- Add tests ensuring zero-vector embeddings are skipped and zero queries return no results

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689641bb65588331a0c8feaa2735d8b3